### PR TITLE
[JK] MCP Tool To Get stop_ids of the next stops we can get to from given stop

### DIFF
--- a/bus-mcp/server.py
+++ b/bus-mcp/server.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict
 from mcp.server.fastmcp import FastMCP
 import asyncio
@@ -7,6 +8,7 @@ from dotenv import load_dotenv
 import os
 ONE_BUS_AWAY_BASE_URL = "https://api.pugetsound.onebusaway.org/api"
 CURR_TIMESTAMP_API ="where/current-time.json"
+ARRIVALS_AND_DEPARTURES_API="where/arrivals-and-departures-for-stop/{stop_id}.json"
 load_dotenv()
 one_bus_away_api_key = os.getenv('ONE_BUS_AWAY_API_KEY')
 mcp = FastMCP("One Bus Away MCP Server")
@@ -33,11 +35,26 @@ async def get_current_time() -> Dict[str, Any]:
     result = response.json()
     print(f"result: {result}")
     return result
-    
+
+@mcp.tool(description="MCP Tool to get the next bus stops from a provided bus stop_id in the Puget Sound, Washington Area")
+async def get_next_stop(stop_id) ->set:
+    request_path = f"{ONE_BUS_AWAY_BASE_URL}/{ARRIVALS_AND_DEPARTURES_API}?key={one_bus_away_api_key}".replace("{stop_id}",stop_id)
+    response = requests.get(request_path)
+    result = response.json()
+    write_file_path = f"{stop_id}_arrivals_and_departures.json"
+    with open(write_file_path,"w") as f:
+        json.dump(result,f)
+    arrivalsAndDepartures = result["data"]["entry"]["arrivalsAndDepartures"]
+    next_stops = set()
+    for entry in arrivalsAndDepartures:
+        next_stops.add(entry["tripStatus"]["nextStop"])
+    print(next_stops)
+    return next_stops  
 
 # test bed
 if __name__ == "__main__":
     print("I am in here")
     asyncio.run(print_hello("This is a test"))
     asyncio.run(get_current_time())
+    asyncio.run(get_next_stop("1_75403"))
     mcp.run()


### PR DESCRIPTION
# DESCRIPTION
- Add mcp tool that gets the next stops we can get to from current stop using the one_bus_api.
- It takes in the stop_id of the current stop and returns a  list of stop_ids for the stops we can get to.

# TESTING PROCEDURE

- cd into the bus-mcp directory
- Ran server using the command: `npx @modelcontextprotocol/inspector uv --directory . run main.py`
- Accessed the server via the local address shown in output and used the get_next_stop tool.