### PR TITLE
add distance calculation using geosidic distance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "uvicorn>=0.23.1",
     "pydantic>=2.7.2",
     "starlette>=0.27.0",
+    "geopy>=2.4.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Using [geodesic distance](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid) as compared to the [Haversine distance](https://en.wikipedia.org/wiki/Haversine_formula). Geodesic is a more accurate representation of planet earth, see [1](https://stackoverflow.com/questions/19412462/getting-distance-between-two-points-based-on-latitude-longitude)

At the moment there's a limitation
- Two points separated by wide non-navigable bodies, think Thames separating two points, we need to go around

Sample response from the mcp tool:
<img width="456" height="897" alt="Screenshot 2025-07-25 at 8 20 26 AM" src="https://github.com/user-attachments/assets/a13cb538-4db4-4cff-a03e-c2dec588c0a5" />

